### PR TITLE
Fix Accessors Issue

### DIFF
--- a/Eloquent/Metadata/ModelMetadata.php
+++ b/Eloquent/Metadata/ModelMetadata.php
@@ -138,6 +138,8 @@ final class ModelMetadata
                 'hidden' => $this->attributeIsHidden($name, $model),
                 'appended' => $model->hasAppended($name),
                 'cast' => $cast,
+                'primary' => false,
+                'nullable' => true,
             ])
             ->values();
     }


### PR DESCRIPTION
If you add an API Resource to a model that has an accessor, it fails because the `primary` and `nullable` keys are not set. I set what seem like reasonable default and it works for my project now.